### PR TITLE
feat: implement consistent SUIT/GOV.CO government portal links display

### DIFF
--- a/src/app/admin/tramites/page.tsx
+++ b/src/app/admin/tramites/page.tsx
@@ -237,18 +237,30 @@ const TramitesAdminPage: React.FC = () => {
       helperText: 'Un requisito por línea. Ejemplo:\nCédula de ciudadanía original y copia\nFormulario de solicitud diligenciado',
     },
     {
-      name: 'visualizacion_suit',
+      name: 'url_suit',
       label: 'URL Portal SUIT',
       type: 'text',
       placeholder: 'https://www.suit.gov.co/tramite/codigo-tramite',
       helperText: 'URL completa del trámite en el portal SUIT',
     },
     {
-      name: 'visualizacion_gov',
+      name: 'visualizacion_suit',
+      label: 'Mostrar enlace SUIT',
+      type: 'checkbox',
+      helperText: 'Activa para mostrar el enlace SUIT cuando la URL sea válida',
+    },
+    {
+      name: 'url_gov',
       label: 'URL Portal GOV.CO',
       type: 'text',
       placeholder: 'https://www.gov.co/tramites-y-servicios/codigo-tramite',
       helperText: 'URL completa del trámite en el portal GOV.CO',
+    },
+    {
+      name: 'visualizacion_gov',
+      label: 'Mostrar enlace GOV.CO',
+      type: 'checkbox',
+      helperText: 'Activa para mostrar el enlace GOV.CO cuando la URL sea válida',
     },
     {
       name: 'instructivo',

--- a/src/app/funcionarios/tramites/page.tsx
+++ b/src/app/funcionarios/tramites/page.tsx
@@ -47,10 +47,10 @@ const validateTramiteData = (formData: Record<string, any>): { isValid: boolean;
 
   // URL validation
   const urlPattern = /^https?:\/\/.+/
-  if (formData.visualizacion_suit && !urlPattern.test(formData.visualizacion_suit)) {
+  if (formData.url_suit && !urlPattern.test(formData.url_suit)) {
     errors.push('La URL del portal SUIT debe ser válida (comenzar con http:// o https://)')
   }
-  if (formData.visualizacion_gov && !urlPattern.test(formData.visualizacion_gov)) {
+  if (formData.url_gov && !urlPattern.test(formData.url_gov)) {
     errors.push('La URL del portal GOV.CO debe ser válida (comenzar con http:// o https://)')
   }
 
@@ -383,7 +383,7 @@ export default function FuncionariosTramitesPage() {
 
     // SECTION 6: Government Portals
     {
-      name: 'visualizacion_suit',
+      name: 'url_suit',
       label: 'URL Portal SUIT',
       type: 'text',
       required: false,
@@ -392,12 +392,28 @@ export default function FuncionariosTramitesPage() {
       section: 'Portales Gubernamentales',
     },
     {
-      name: 'visualizacion_gov',
+      name: 'visualizacion_suit',
+      label: 'Mostrar enlace SUIT',
+      type: 'checkbox',
+      required: false,
+      helperText: 'Activa para mostrar el enlace SUIT cuando la URL sea válida',
+      section: 'Portales Gubernamentales',
+    },
+    {
+      name: 'url_gov',
       label: 'URL Portal GOV.CO',
       type: 'text',
       required: false,
       placeholder: 'https://www.gov.co/tramites-y-servicios/codigo-tramite',
       helperText: 'Enlace al trámite en el portal GOV.CO',
+      section: 'Portales Gubernamentales',
+    },
+    {
+      name: 'visualizacion_gov',
+      label: 'Mostrar enlace GOV.CO',
+      type: 'checkbox',
+      required: false,
+      helperText: 'Activa para mostrar el enlace GOV.CO cuando la URL sea válida',
       section: 'Portales Gubernamentales',
     },
 
@@ -489,8 +505,10 @@ export default function FuncionariosTramitesPage() {
         modalidad: formData.modalidad as 'virtual' | 'presencial' | 'mixto',
         categoria: (formData.categoria as string) || null,
         observaciones: (formData.observaciones as string) || null,
-        visualizacion_suit: (formData.visualizacion_suit as string) || null,
-        visualizacion_gov: (formData.visualizacion_gov as string) || null,
+        url_suit: (formData.url_suit as string) || null,
+        visualizacion_suit: Boolean(formData.visualizacion_suit) || false,
+        url_gov: (formData.url_gov as string) || null,
+        visualizacion_gov: Boolean(formData.visualizacion_gov) || false,
       }
 
       await tramitesService.create(tramiteData)
@@ -544,8 +562,10 @@ export default function FuncionariosTramitesPage() {
         modalidad: formData.modalidad as 'virtual' | 'presencial' | 'mixto',
         categoria: (formData.categoria as string) || null,
         observaciones: (formData.observaciones as string) || null,
-        visualizacion_suit: (formData.visualizacion_suit as string) || null,
-        visualizacion_gov: (formData.visualizacion_gov as string) || null,
+        url_suit: (formData.url_suit as string) || null,
+        visualizacion_suit: Boolean(formData.visualizacion_suit) || false,
+        url_gov: (formData.url_gov as string) || null,
+        visualizacion_gov: Boolean(formData.visualizacion_gov) || false,
       }
 
       await tramitesService.update(selectedTramite.id, updates)
@@ -777,8 +797,10 @@ export default function FuncionariosTramitesPage() {
                   : (selectedTramite.instructivo || ''),
 
                 // Government Portals
-                visualizacion_suit: selectedTramite.visualizacion_suit || '',
-                visualizacion_gov: selectedTramite.visualizacion_gov || '',
+                url_suit: selectedTramite.url_suit || '',
+                visualizacion_suit: Boolean(selectedTramite.visualizacion_suit),
+                url_gov: selectedTramite.url_gov || '',
+                visualizacion_gov: Boolean(selectedTramite.visualizacion_gov),
 
                 // Additional Information
                 observaciones: selectedTramite.observaciones || '',

--- a/src/components/molecules/TramiteCardEnhanced/TramiteCardEnhanced.tsx
+++ b/src/components/molecules/TramiteCardEnhanced/TramiteCardEnhanced.tsx
@@ -336,34 +336,30 @@ export const TramiteCardEnhanced: React.FC<TramiteCardEnhancedProps> = ({
           </div>
         )}
 
-          {/* Government Portal Links - Fix: Support both old and new URL field structure */}
-          {((tramite.url_suit && tramite.visualizacion_suit) ||
-            (tramite.url_gov && tramite.visualizacion_gov) ||
-            (typeof tramite.visualizacion_suit === 'string' && tramite.visualizacion_suit) ||
-            (typeof tramite.visualizacion_gov === 'string' && tramite.visualizacion_gov)) && (
+          {/* Government Portal Links - show only when URL is valid and flag is true */}
+          {(((tramite.url_suit && /^https?:\/\//.test(tramite.url_suit)) && tramite.visualizacion_suit === true) ||
+            ((tramite.url_gov && /^https?:\/\//.test(tramite.url_gov)) && tramite.visualizacion_gov === true)) && (
             <div className="mt-4 pt-4 border-t border-gray-200">
               <div className="flex items-center gap-4 text-sm">
                 <span className="text-gray-600 font-medium">Enlaces oficiales:</span>
-                {/* SUIT Link - Support both new (url_suit + visualizacion_suit boolean) and old (visualizacion_suit string) formats */}
-                {((tramite.url_suit && tramite.visualizacion_suit) ||
-                  (typeof tramite.visualizacion_suit === 'string' && tramite.visualizacion_suit)) && (
+                {tramite.url_suit && /^https?:\/\//.test(tramite.url_suit) && tramite.visualizacion_suit === true && (
                   <a
-                    href={tramite.url_suit || (typeof tramite.visualizacion_suit === 'string' ? tramite.visualizacion_suit : '')}
+                    href={tramite.url_suit}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-blue-600 hover:text-blue-800 underline"
+                    aria-label="Abrir trámite en SUIT (se abre en nueva pestaña)"
                   >
                     SUIT
                   </a>
                 )}
-                {/* GOV.CO Link - Support both new (url_gov + visualizacion_gov boolean) and old (visualizacion_gov string) formats */}
-                {((tramite.url_gov && tramite.visualizacion_gov) ||
-                  (typeof tramite.visualizacion_gov === 'string' && tramite.visualizacion_gov)) && (
+                {tramite.url_gov && /^https?:\/\//.test(tramite.url_gov) && tramite.visualizacion_gov === true && (
                   <a
-                    href={tramite.url_gov || (typeof tramite.visualizacion_gov === 'string' ? tramite.visualizacion_gov : '')}
+                    href={tramite.url_gov}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-blue-600 hover:text-blue-800 underline"
+                    aria-label="Abrir trámite en GOV.CO (se abre en nueva pestaña)"
                   >
                     GOV.CO
                   </a>

--- a/src/components/molecules/UnifiedServiceCard/UnifiedServiceCard.tsx
+++ b/src/components/molecules/UnifiedServiceCard/UnifiedServiceCard.tsx
@@ -303,34 +303,30 @@ export const UnifiedServiceCard: React.FC<UnifiedServiceCardProps> = ({
                     ))}
                   </ul>
                   
-                  {/* Government portal links - Fix: Support both old and new URL field structure */}
-                  {((service.originalData?.url_suit && service.originalData?.visualizacion_suit) ||
-                    (service.originalData?.url_gov && service.originalData?.visualizacion_gov) ||
-                    (typeof service.originalData?.visualizacion_suit === 'string' && service.originalData?.visualizacion_suit) ||
-                    (typeof service.originalData?.visualizacion_gov === 'string' && service.originalData?.visualizacion_gov)) && (
+                  {/* Government portal links - show only when URL is valid and flag is true */}
+                  {(((service.originalData?.url_suit && /^https?:\/\//.test(service.originalData.url_suit)) && service.originalData?.visualizacion_suit === true) ||
+                    ((service.originalData?.url_gov && /^https?:\/\//.test(service.originalData.url_gov)) && service.originalData?.visualizacion_gov === true)) && (
                     <div className="mt-3 pt-3 border-t border-amber-200">
                       <div className="flex items-center gap-2 text-xs text-gray-600">
                         <span>Enlaces oficiales:</span>
-                        {/* SUIT Link - Support both new and old formats */}
-                        {((service.originalData?.url_suit && service.originalData?.visualizacion_suit) ||
-                          (typeof service.originalData?.visualizacion_suit === 'string' && service.originalData?.visualizacion_suit)) && (
+                        {service.originalData?.url_suit && /^https?:\/\//.test(service.originalData.url_suit) && service.originalData?.visualizacion_suit === true && (
                           <a
-                            href={service.originalData.url_suit || (typeof service.originalData.visualizacion_suit === 'string' ? service.originalData.visualizacion_suit : '')}
+                            href={service.originalData.url_suit}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-blue-600 hover:text-blue-800"
+                            aria-label="Abrir trámite en SUIT (se abre en nueva pestaña)"
                           >
                             SUIT
                           </a>
                         )}
-                        {/* GOV.CO Link - Support both new and old formats */}
-                        {((service.originalData?.url_gov && service.originalData?.visualizacion_gov) ||
-                          (typeof service.originalData?.visualizacion_gov === 'string' && service.originalData?.visualizacion_gov)) && (
+                        {service.originalData?.url_gov && /^https?:\/\//.test(service.originalData.url_gov) && service.originalData?.visualizacion_gov === true && (
                           <a
-                            href={service.originalData.url_gov || (typeof service.originalData.visualizacion_gov === 'string' ? service.originalData.visualizacion_gov : '')}
+                            href={service.originalData.url_gov}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-blue-600 hover:text-blue-800"
+                            aria-label="Abrir trámite en GOV.CO (se abre en nueva pestaña)"
                           >
                             GOV.CO
                           </a>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -419,8 +419,9 @@ export interface ServiceEnhanced {
   formulario?: string
   tiempo_respuesta?: string
   tiene_pago: boolean
-  visualizacion_suit?: string | boolean  // Support both URL string (old) and boolean (new)
-  visualizacion_gov?: string | boolean   // Support both URL string (old) and boolean (new)
+  // Visibility flags (always boolean in unified model)
+  visualizacion_suit?: boolean
+  visualizacion_gov?: boolean
   // New URL fields for proper database mapping
   url_suit?: string
   url_gov?: string

--- a/src/utils/serviceTransformers.ts
+++ b/src/utils/serviceTransformers.ts
@@ -109,10 +109,10 @@ export function transformUnifiedServiceToServiceEnhanced(service: UnifiedService
     tiempo_respuesta: service.tiempo_respuesta,
     // Fix field name mismatch: requiere_pago -> tiene_pago
     tiene_pago: service.requiere_pago || false,
-    // Fix: Support both old and new URL field structure for backward compatibility
-    visualizacion_suit: service.url_suit || service.visualizacion_suit,
-    visualizacion_gov: service.url_gov || service.visualizacion_gov,
-    // Add new URL fields for proper card display
+    // Ensure flags remain boolean; URLs are provided via url_suit/url_gov
+    visualizacion_suit: Boolean(service.visualizacion_suit),
+    visualizacion_gov: Boolean(service.visualizacion_gov),
+    // Provide URL fields explicitly for card display
     url_suit: service.url_suit,
     url_gov: service.url_gov,
     requisitos: service.requisitos || [],


### PR DESCRIPTION
- Data migration: backfilled official government portal URLs from tramites (visualizacion_* legacy strings) into servicios (url_*), enabling boolean flags visualizacion_suit/visualizacion_gov where applicable.
- UI logic: public trámites cards now require a valid http(s) URL AND the corresponding boolean flag set to true to render SUIT/GOV.CO links.
- Rationale: unify behavior across all trámites and ensure reliability by removing legacy string/flag ambiguity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added visibility toggles to show/hide SUIT and GOV.CO links.
  - Introduced explicit SUIT URL field (renamed) and added GOV.CO URL field.
  - Improved accessibility with aria-labels for official links.
  - Reordered fields: SUIT URL and toggle appear before GOV.CO.
- Bug Fixes
  - Official links now display only when URLs are valid (http/https) and visibility is enabled.
  - Updated form validation to target the new URL fields, preventing invalid link rendering.
- UI Improvements
  - Consistent data display and form behavior across admin and staff views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->